### PR TITLE
Installable versions of Ray are now supported

### DIFF
--- a/core/train.py
+++ b/core/train.py
@@ -339,8 +339,10 @@ def train(config, summary_writer=None):
     storage = SharedStorage.remote(config.get_uniform_network())
     replay_buffer = ReplayBuffer.remote(batch_size=config.batch_size, capacity=config.window_size,
                                         prob_alpha=config.priority_prob_alpha)
-    workers = [DataWorker.remote(rank, config, storage, replay_buffer).run.remote()
+    workers = [DataWorker.remote(rank, config, storage, replay_buffer)
                for rank in range(0, config.num_actors)]
+    for worker in workers:
+        worker.run.remote()
     workers += [_test.remote(config, storage)]
     _train(config, storage, replay_buffer, summary_writer)
     ray.wait(workers, len(workers))


### PR DESCRIPTION
Here's my fix for issue (https://github.com/koulanurag/muzero-pytorch/issues/4). I haven't fully tested the muzero algo yet, but without this fix, the versions of Ray installable from pip will fail. With this fix, it will show some cartpole training with this command:

```
(venv) grifball@grifball-Nobilis:~/checkout/muzero-pytorch$ python main.py --env CartPole-v1 --case classic_control --opr test
```
This fix is based on similar fixes from this issue on the ray project:
https://github.com/ray-project/ray/issues/6265