### PR TITLE
Add support for Apple's Metal Performance Shaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ _Note: This implementation has just been tested on CartPole-v1 and would require
 | `--use_target_model`           |Use target model for bootstrap value estimation (default: False)|
 | `--result_dir`                 |Directory Path to store results (defaut: current working directory)|
 | `--no_cuda`                    |no cuda usage (default: False)|
+| `--no_mps`                     |no mps (Metal Performance Shaders) usage (default: False)|
 | `--debug`                      |If enables, logs additional values  (default:False)|
 | `--render`                     |Renders the environment (default: False)|
 | `--force`                      |Overrides past results (default: False)|

--- a/main.py
+++ b/main.py
@@ -23,6 +23,8 @@ if __name__ == '__main__':
     parser.add_argument('--opr', required=True, choices=['train', 'test'])
     parser.add_argument('--no_cuda', action='store_true', default=False,
                         help='no cuda usage (default: %(default)s)')
+    parser.add_argument('--no_mps', action='store_true', default=False,
+                        help='no mps (Metal Performance Shaders) usage (default: %(default)s)')
     parser.add_argument('--debug', action='store_true', default=False,
                         help='If enabled, logs additional values  '
                              '(gradients, target value, reward distribution, etc.) (default: %(default)s)')
@@ -49,7 +51,8 @@ if __name__ == '__main__':
 
     # Process arguments
     args = parser.parse_args()
-    args.device = 'cuda' if (not args.no_cuda) and torch.cuda.is_available() else 'cpu'
+    args.device = 'cuda' if (not args.no_cuda) and torch.cuda.is_available() else (
+        'mps' if (not args.no_mps) and torch.backends.mps.is_available() else 'cpu')
     assert args.revisit_policy_search_rate is None or 0 <= args.revisit_policy_search_rate <= 1, \
         ' Revisit policy search rate should be in [0,1]'
 


### PR DESCRIPTION
This allows GPU acceleration on devices that support Apple's Metal API, e.g. with M1 chip.

- adding `mps` device type, with preference for CUDA
- adding `no_mps` argument