### PR TITLE
Fix old step API deprecation warning

### DIFF
--- a/config/classic_control/__init__.py
+++ b/config/classic_control/__init__.py
@@ -46,7 +46,7 @@ class ClassicControlConfig(BaseMuZeroConfig):
                          self.inverse_value_transform, self.inverse_reward_transform)
 
     def new_game(self, seed=None, save_video=False, save_path=None, video_callable=None, uid=None):
-        env = gym.make(self.env_name)
+        env = gym.make(self.env_name, new_step_api=True)
         if seed is not None:
             env.seed(seed)
 

--- a/config/classic_control/env_wrapper.py
+++ b/config/classic_control/env_wrapper.py
@@ -20,7 +20,7 @@ class ClassicControlWrapper(Game):
         return [Action(_) for _ in range(self.env.action_space.n)]
 
     def step(self, action):
-        obs, reward, done, info = self.env.step(action)
+        obs, reward, done, _, info = self.env.step(action)
 
         self.rewards.append(reward)
         self.history.append(action)


### PR DESCRIPTION
OpenAI Gym shows a warning:

    DeprecationWarning: WARN: Initializing wrapper in old step API which returns one bool instead of two. It is recommended to set `new_step_api=True` to use new step API. This will be the default behaviour in future.

This is fixed by enabling `new_step_api` and handling the additional step return value.