### PR TITLE
Fix deprecated Monitor wrapper with RecordVideo

### DIFF
--- a/config/classic_control/__init__.py
+++ b/config/classic_control/__init__.py
@@ -51,8 +51,8 @@ class ClassicControlConfig(BaseMuZeroConfig):
             env.seed(seed)
 
         if save_video:
-            from gym.wrappers import Monitor
-            env = Monitor(env, directory=save_path, force=True, video_callable=video_callable, uid=uid)
+            from gym.wrappers import RecordVideo
+            env = RecordVideo(env, video_folder=save_path, name_prefix=f"rl-video-{uid}", new_step_api=True)
         return ClassicControlWrapper(env, discount=self.discount, k=4)
 
     def scalar_reward_loss(self, prediction, target):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ future==0.18.2
 google-auth==1.8.2
 google-auth-oauthlib==0.4.1
 grpcio==1.25.0
-gym==0.15.4
+gym==0.20.0
 idna==2.8
 importlib-metadata==1.3.0
 jsonschema==3.2.0


### PR DESCRIPTION
OpenAI Gym's `Monitor` wrapper is deprecated and replace by `RecordVideo`. This requires bumping gym to version 0.20.0.