### PR TITLE
Fix SIGTERM log by ray when multiprocess.Manager shuts down

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from core.test import test
 from core.train import train
 from core.utils import init_logger, make_results_dir
 
-ray.init()
 if __name__ == '__main__':
     # Lets gather arguments
     parser = argparse.ArgumentParser(description='MuZero Pytorch Implementation')
@@ -76,9 +75,10 @@ if __name__ == '__main__':
 
     try:
         if args.opr == 'train':
+            ray.init()
             summary_writer = SummaryWriter(exp_path, flush_secs=10)
             train(muzero_config, summary_writer)
-
+            ray.shutdown()
         elif args.opr == 'test':
             assert os.path.exists(muzero_config.model_path), 'model not found at {}'.format(muzero_config.model_path)
             model = muzero_config.get_uniform_network().to('cpu')
@@ -88,6 +88,5 @@ if __name__ == '__main__':
             logging.getLogger('test').info('Test Score: {}'.format(test_score))
         else:
             raise Exception('Please select a valid operation(--opr) to be performed')
-        ray.shutdown()
     except Exception as e:
         logging.getLogger('root').error(e, exc_info=True)


### PR DESCRIPTION
In test runs, the `multiprocessing.Manager` sends a SIGTERM during `manager.shutdown()`, which is implicitly invoked when `manager` goes out of scope. Because Ray is initialized, this causes the following log:

```
*** SIGTERM received at time=1659740361 ***
..
libc++abi: terminating
```

While not affecting the test run, this can be a misleading message. This is addressed this by moving `ray.init()` into the training code path.