### PR TITLE
Add num_actors to args

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ _Note: This implementation has just been tested on CartPole-v1 and would require
 | `--render`                     |Renders the environment (default: False)|
 | `--force`                      |Overrides past results (default: False)|
 | `--seed`                       |seed (default: 0)|
+| `--num_actors`                 |Number of actors running concurrently (default: 32)|
 | `--test_episodes`              |Evaluation episode count (default: 10)|
 
 ```Note: default: None => Values are loaded from the corresponding config```

--- a/config/classic_control/__init__.py
+++ b/config/classic_control/__init__.py
@@ -18,7 +18,6 @@ class ClassicControlConfig(BaseMuZeroConfig):
             num_simulations=50,
             batch_size=128,
             td_steps=5,
-            num_actors=32,
             lr_init=0.05,
             lr_decay_rate=0.01,
             lr_decay_steps=10000,

--- a/core/config.py
+++ b/core/config.py
@@ -25,7 +25,6 @@ class BaseMuZeroConfig(object):
                  num_simulations: int,
                  batch_size: int,
                  td_steps: int,
-                 num_actors: int,
                  lr_init: float,
                  lr_decay_rate: float,
                  lr_decay_steps: float,
@@ -36,7 +35,6 @@ class BaseMuZeroConfig(object):
 
         # Self-Play
         self.action_space_size = None
-        self.num_actors = num_actors
 
         self.max_moves = max_moves
         self.num_simulations = num_simulations
@@ -76,6 +74,7 @@ class BaseMuZeroConfig(object):
         self.seed = None
         self.value_support = value_support
         self.reward_support = reward_support
+        self.num_actors = None
 
         # optimization control
         self.weight_decay = 1e-4

--- a/core/config.py
+++ b/core/config.py
@@ -175,6 +175,7 @@ class BaseMuZeroConfig(object):
         self.debug = args.debug
         self.device = args.device
         self.use_max_priority = (args.use_max_priority and args.use_priority)
+        self.num_actors = args.num_actors
 
         if args.value_loss_coeff is not None:
             self.value_loss_coeff = args.value_loss_coeff

--- a/main.py
+++ b/main.py
@@ -44,6 +44,8 @@ if __name__ == '__main__':
                              'Also, priority for new data is calculated based on loss (default: False)')
     parser.add_argument('--use_target_model', action='store_true', default=False,
                         help='Use target model for bootstrap value estimation (default: %(default)s)')
+    parser.add_argument('--num_actors', type=int, default=32,
+                        help='Number of actors running concurrently (default: %(default)s)')
     parser.add_argument('--test_episodes', type=int, default=10,
                         help='Evaluation episode count (default: %(default)s)')
 


### PR DESCRIPTION
The default `num_actors=32` in ClassicControlConfig seems to perform less than an actor count that is close to the CPU core count. This PR makes `num_actors` configurable from the command line.